### PR TITLE
feat: add event-based APIs

### DIFF
--- a/packages/robot-local/src/main/events.ts
+++ b/packages/robot-local/src/main/events.ts
@@ -1,4 +1,4 @@
-import { JobInput, JobOutput } from '@automationcloud/robot';
+import { JobInput, JobOutput, JobState } from '@automationcloud/robot';
 import { EventEmitter } from 'events';
 import { injectable } from 'inversify';
 
@@ -7,10 +7,12 @@ export interface JobEvents {
     emit(event: 'output', output: JobOutput): boolean;
     emit(event: 'inputRequested', key: string): boolean;
     emit(event: 'error', error: Error): boolean;
+    emit(event: 'stateChanged', newState: JobState, previousState: JobState): boolean;
     on(event: 'input', fn: (input: JobInput) => void): this;
     on(event: 'output', fn: (output: JobOutput) => void): this;
     on(event: 'inputRequested', fn: (key: string) => void): this;
     on(event: 'error', fn: (error: Error) => void): this;
+    on(event: 'stateChanged', fn: (newState: JobState, previousState: JobState) => void): this;
 }
 
 @injectable()

--- a/packages/robot-local/src/test/specs/events.test.ts
+++ b/packages/robot-local/src/test/specs/events.test.ts
@@ -1,0 +1,125 @@
+import { LocalRobot } from '../../main/local-robot';
+import assert from 'assert';
+import { JobState } from '@automationcloud/robot';
+
+describe('Events', () => {
+
+    const script = {
+        id: 'my-script',
+        contexts: [
+            {
+                type: 'main',
+                children: [
+                    {
+                        type: 'Flow.output',
+                        outputKey: 'echo',
+                        pipeline: [
+                            {
+                                type: 'Value.getInput',
+                                inputKey: 'value'
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    };
+
+    describe('onStateChanged', () => {
+        describe('AWAITING_INPUT', () => {
+            it('emits on awaiting input', async () => {
+                let called = false;
+                const robot = new LocalRobot({ script });
+                const job = await robot.createJob();
+                job.onStateChanged(async state => {
+                    if (state === JobState.AWAITING_INPUT) {
+                        called = true;
+                        await job.submitInput('value', { foo: 1 });
+                    }
+                });
+                await job.waitForCompletion();
+                assert.equal(called, true);
+                assert.deepEqual(await job.getOutput('echo'), { foo: 1 });
+            });
+        });
+
+        describe('SUCCESS', () => {
+            it('emits on success', async () => {
+                let called = false;
+                const robot = new LocalRobot({ script });
+                const job = await robot.createJob({ input: { value: '123' } });
+                job.onStateChanged(async state => {
+                    if (state === JobState.SUCCESS) {
+                        called = true;
+                    }
+                });
+                await job.waitForCompletion();
+                assert.equal(called, true);
+            });
+        });
+
+        describe('FAIL', () => {
+            it('emits on fail', async () => {
+                let called = false;
+                const robot = new LocalRobot({ script });
+                const job = await robot.createJob();
+                job.onAwaitingInput('value', () => {
+                    throw new Error('boo');
+                });
+                job.onStateChanged(async state => {
+                    if (state === JobState.FAIL) {
+                        called = true;
+                    }
+                });
+                await job.waitForCompletion().catch(() => {});
+                assert.equal(called, true);
+            });
+        });
+
+        describe('integration', () => {
+            it('emits a sequence of state transitions', async () => {
+                const states: JobState[] = [];
+                const robot = new LocalRobot({ script });
+                const job = await robot.createJob();
+                job.onStateChanged(async state => {
+                    states.push(state);
+                });
+                job.onAwaitingInput('value', () => {
+                    return { foo: 1 };
+                });
+                await job.waitForCompletion();
+                assert.deepEqual(states, [JobState.PROCESSING, JobState.AWAITING_INPUT, JobState.SUCCESS]);
+            });
+        });
+    });
+
+    describe('onSuccess', () => {
+        it('emits when job finishes successfully', async () => {
+            let called = false;
+            const robot = new LocalRobot({ script });
+            const job = await robot.createJob({ input: { value: '123' }});
+            job.onSuccess(async () => {
+                called = true;
+            });
+            await job.waitForCompletion();
+            assert.equal(called, true);
+        });
+    });
+
+    describe('onFail', () => {
+        it('emits when job fails', async () => {
+            let error: any = null;
+            const robot = new LocalRobot({ script });
+            const job = await robot.createJob();
+            job.onFail(async err => {
+                error = err;
+            });
+            job.onAwaitingInput('value', () => {
+                throw new Error('boo');
+            });
+            await job.waitForCompletion().catch(() => {});
+            assert.equal(error?.message, 'boo');
+        });
+    });
+
+});

--- a/packages/robot/src/main/job.ts
+++ b/packages/robot/src/main/job.ts
@@ -4,16 +4,20 @@ export interface JobInitParams {
 }
 
 export interface Job {
-    readonly awaitingInputKey: string | null;
     readonly category: JobCategory;
+    readonly state: JobState;
+    readonly awaitingInputKey: string | null;
 
     submitInput(key: string, data: any): Promise<void>;
     getOutput(key: string): Promise<any | undefined>;
     waitForCompletion(): Promise<void>;
     waitForOutputs(...keys: string[]): Promise<any[]>;
+    cancel(): Promise<void>;
     onAwaitingInput(inputKey: string, fn: () => any | Promise<any>): JobEventHandler;
     onOutput(outputKey: string, fn: (data: any) => void | Promise<void>): JobEventHandler;
-    cancel(): Promise<void>;
+    onFail(fn: (err: Error) => void | Promise<void>): JobEventHandler;
+    onSuccess(fn: () => void | Promise<void>): JobEventHandler;
+    onStateChanged(fn: (newState: JobState) => void | Promise<void>): JobEventHandler;
 }
 
 export enum JobState {


### PR DESCRIPTION
Here I've added a basic set of event-based APIs for jobs (as always, see sample usage in tests).

It might seem odd to not use existing EventEmitter-based interface, but this is done deliberately for following reasons:

1. EventEmitter is notorious for its clumsy API when it comes to unsubscribing; our interface mitigates that by returning an unsubscribe function which holds a reference to the handler you install — this approach has proven to be much nicer to work with.
2. EventEmitter is not natively available in all environments (specifically, not in browser)
3. Most important (and subtle) one: our custom methods allow exceptions thrown from handlers (either synchronously or asynchronously) to be hooked back into a job. You can find few examples in tests whereby an error thrown from `job.onAwaitingInput` is further propagated into a `job.onFail` — and is even thrown from `waitForCompletion` promise — which is a **really really cool** trick 🐰 🎩 