### PR TITLE
add resetIfNeeded() to cloud-job

### DIFF
--- a/packages/cloud-robot/src/main/ac-api.ts
+++ b/packages/cloud-robot/src/main/ac-api.ts
@@ -112,6 +112,16 @@ export class AcApi {
         });
         return data;
     }
+
+    async resetJob(jobId: string, fromInputKey: string, preserveOutputs: string[]) {
+        const { data } = await this.request.post(`/jobs/${jobId}/reset`, {
+            body: {
+                fromInputKey,
+                preserveOutputs
+            }
+        });
+        return data;
+    }
 }
 
 export interface AcJob {


### PR DESCRIPTION
I've added the jobReset feature to cloud-job. This works by automatically resetting the job if an input that has been previously submitted is submitted again. It preserves all of the outputs that were outputted before the previous input was made by checking their timestamps against the previous input.